### PR TITLE
Change the action for nodejs chocolatey from install to upgrade

### DIFF
--- a/recipes/nodejs_from_chocolatey.rb
+++ b/recipes/nodejs_from_chocolatey.rb
@@ -18,11 +18,11 @@
 
 chocolatey_package 'nodejs-lts' do
   version node['nodejs']['version']
-  action :install
+  action :upgrade
   only_if node['nodejs']['version']
 end
 
 chocolatey_package 'nodejs-lts' do
-  action :install
+  action :upgrade
   not_if node['nodejs']['version']
 end


### PR DESCRIPTION
### Description

This way it will upgrade to the active LTS version even if the version is maintenance LTS

### Issues Resolved

When the version is a Maintenance LTS (v8), it will still upgrade it to Active LTS (v10)

### Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
