### PR TITLE
IXUAT-6388 fixing nodejs-version

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -27,6 +27,7 @@ else
 end
 
 default['nodejs']['version'] = '10.15.3'
+default['nodejs']['use_version'] = true 
 
 default['nodejs']['prefix_url']['node'] = 'https://nodejs.org/dist/'
 

--- a/recipes/nodejs_from_chocolatey.rb
+++ b/recipes/nodejs_from_chocolatey.rb
@@ -19,10 +19,11 @@
 chocolatey_package 'nodejs-lts' do
   version node['nodejs']['version']
   action :upgrade
-  only_if node['nodejs']['version']
+  only_if { node['nodejs']['use_version'] == true }
 end
 
 chocolatey_package 'nodejs-lts' do
   action :upgrade
-  not_if node['nodejs']['version']
+  not_if { node['nodejs']['use_version'] == true}
 end
+


### PR DESCRIPTION
### Description
chocolaty installed the latest version of nodejs instead of the specific version(10.15.3) which is defined in the nodejs attributes. It happened because of the if condition statement tried to compare a string variable to boolean and the condition returned to FALSE in all cases. 

### Issues Resolved
Issue is resolved by fixing the _if_ statement and using a boolean variable. 

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
