### PR TITLE
DO-233: Upgrade NodeJS version to 10.22.1

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,8 +26,8 @@ else
   default['nodejs']['install_method'] = 'source'
 end
 
-default['nodejs']['version'] = '10.15.3'
-default['nodejs']['use_version'] = true 
+default['nodejs']['version'] = '10.22.1'
+default['nodejs']['use_version'] = true
 
 default['nodejs']['prefix_url']['node'] = 'https://nodejs.org/dist/'
 


### PR DESCRIPTION
### Description

Upgrade the version to 10.22.1 [due to a fix on a vulnerability](https://nodejs.org/en/blog/vulnerability/september-2020-security-releases/).

### Issues Resolved

The fixed issue is on [NodeJS website](https://nodejs.org/en/blog/vulnerability/september-2020-security-releases/).

### Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
